### PR TITLE
Update bundler CLI and service to new Solana modules

### DIFF
--- a/crates/bundler-cli/Cargo.toml
+++ b/crates/bundler-cli/Cargo.toml
@@ -25,3 +25,6 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 toml.workspace = true
 solana-sdk.workspace = true
+solana-transaction-status.workspace = true
+solana-commitment-config.workspace = true
+chrono.workspace = true

--- a/crates/bundler-cli/src/lib.rs
+++ b/crates/bundler-cli/src/lib.rs
@@ -2,31 +2,35 @@ use anyhow::{Context, Result};
 use bundler_config::BundlerConfig;
 use bundler_core::BundlerService;
 use bundler_types::{BundleRequest, BundleStatus, TransactionStatus};
+use chrono::Utc;
 use clap::{Parser, Subcommand};
 use serde_json;
+use solana_commitment_config::CommitmentLevel;
+use solana_transaction_status::option_serializer::OptionSerializer;
 use std::path::PathBuf;
-use tokio;
 use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 /// Solana Transaction Bundler CLI
 #[derive(Parser)]
 #[command(name = "bundler")]
-#[command(about = "A production-ready Solana transaction bundler with low latency and high success rate")]
+#[command(
+    about = "A production-ready Solana transaction bundler with low latency and high success rate"
+)]
 #[command(version = "0.1.0")]
 pub struct Cli {
     /// Configuration file path
     #[arg(short, long, default_value = "bundler.config.toml")]
     pub config: PathBuf,
-    
+
     /// Log level (trace, debug, info, warn, error)
     #[arg(short, long, default_value = "info")]
     pub log_level: String,
-    
+
     /// Log format (json, pretty)
     #[arg(long, default_value = "pretty")]
     pub log_format: String,
-    
+
     #[command(subcommand)]
     pub command: Commands,
 }
@@ -38,63 +42,63 @@ pub enum Commands {
         /// Path to JSON file containing bundle request
         #[arg(value_name = "FILE")]
         file: PathBuf,
-        
+
         /// Show detailed logs
         #[arg(short, long)]
         verbose: bool,
     },
-    
+
     /// Submit a bundle of transactions
     Submit {
         /// Path to JSON file containing bundle request
         #[arg(value_name = "FILE")]
         file: PathBuf,
-        
+
         /// Force atomic execution (all transactions must succeed)
         #[arg(short, long)]
         atomic: bool,
-        
+
         /// Override compute unit limit
         #[arg(long)]
         cu_limit: Option<u32>,
-        
+
         /// Override compute unit price strategy (auto or specific lamports)
         #[arg(long)]
         cu_price: Option<String>,
-        
+
         /// Wait for finalization before returning
         #[arg(short, long)]
         wait: bool,
-        
+
         /// Timeout in seconds for waiting
         #[arg(long, default_value = "60")]
         timeout: u64,
     },
-    
+
     /// Check the status of a transaction or bundle
     Status {
         /// Transaction signature or request ID
         #[arg(value_name = "ID")]
         id: String,
-        
+
         /// Show detailed information
         #[arg(short, long)]
         verbose: bool,
     },
-    
+
     /// Show health status of the bundler service
     Health {
         /// Show detailed component status
         #[arg(short, long)]
         verbose: bool,
     },
-    
+
     /// Show configuration and validate settings
     Config {
         /// Show the current configuration
         #[arg(short, long)]
         show: bool,
-        
+
         /// Validate configuration without starting service
         #[arg(short, long)]
         validate: bool,
@@ -110,73 +114,68 @@ impl CliRunner {
     /// Create a new CLI runner
     pub async fn new(config_path: &PathBuf) -> Result<Self> {
         let config = if config_path.exists() {
-            BundlerConfig::load_from_path(config_path)
-                .context("Failed to load configuration")?
+            BundlerConfig::load_from_path(config_path).context("Failed to load configuration")?
         } else {
             warn!("Configuration file not found, using defaults");
             BundlerConfig::default()
         };
-        
-        let service = BundlerService::new(config.clone()).await
+
+        let service = BundlerService::new(config.clone())
+            .await
             .context("Failed to initialize bundler service")?;
-        
+
         Ok(Self { config, service })
     }
-    
+
     /// Run the CLI command
     pub async fn run(&self, command: Commands) -> Result<()> {
         match command {
-            Commands::Simulate { file, verbose } => {
-                self.simulate_command(file, verbose).await
-            }
-            Commands::Submit { 
-                file, 
-                atomic, 
-                cu_limit, 
-                cu_price, 
-                wait, 
-                timeout 
+            Commands::Simulate { file, verbose } => self.simulate_command(file, verbose).await,
+            Commands::Submit {
+                file,
+                atomic,
+                cu_limit,
+                cu_price,
+                wait,
+                timeout,
             } => {
-                self.submit_command(file, atomic, cu_limit, cu_price, wait, timeout).await
+                self.submit_command(file, atomic, cu_limit, cu_price, wait, timeout)
+                    .await
             }
-            Commands::Status { id, verbose } => {
-                self.status_command(id, verbose).await
-            }
-            Commands::Health { verbose } => {
-                self.health_command(verbose).await
-            }
-            Commands::Config { show, validate } => {
-                self.config_command(show, validate).await
-            }
+            Commands::Status { id, verbose } => self.status_command(id, verbose).await,
+            Commands::Health { verbose } => self.health_command(verbose).await,
+            Commands::Config { show, validate } => self.config_command(show, validate).await,
         }
     }
-    
+
     /// Handle simulate command
     async fn simulate_command(&self, file: PathBuf, verbose: bool) -> Result<()> {
         info!("Simulating bundle from file: {}", file.display());
-        
+
         let bundle_request = self.load_bundle_request(&file)?;
-        
+
         // Create transactions from the request
-        let instructions: Vec<_> = bundle_request.instructions
+        let instructions: Vec<solana_sdk::instruction::Instruction> = bundle_request
+            .instructions
             .iter()
-            .map(|ix| ix.clone().into())
+            .cloned()
+            .map(Into::into)
             .collect();
-        
+
         // Simulate each instruction
         for (i, instruction) in instructions.iter().enumerate() {
             println!("Simulating instruction {} of {}", i + 1, instructions.len());
-            
+
             // Create a simple transaction for simulation
             let fee_payer = self.service.get_fee_payer_pubkey().await?;
             let mut transaction = solana_sdk::transaction::Transaction::new_with_payer(
                 &[instruction.clone()],
                 Some(&fee_payer),
             );
-            
+
             // Set a dummy blockhash for simulation
             transaction.message.recent_blockhash = solana_sdk::hash::Hash::new_unique();
-            
+
             match self.service.simulate_transaction(&transaction).await {
                 Ok(result) => {
                     println!("✅ Simulation successful");
@@ -186,7 +185,7 @@ impl CliRunner {
                     if let Some(fee) = result.estimated_fee {
                         println!("   Estimated fee: {} lamports", fee);
                     }
-                    
+
                     if verbose && !result.logs.is_empty() {
                         println!("   Logs:");
                         for log in &result.logs {
@@ -202,10 +201,10 @@ impl CliRunner {
                 }
             }
         }
-        
+
         Ok(())
     }
-    
+
     /// Handle submit command
     async fn submit_command(
         &self,
@@ -217,28 +216,27 @@ impl CliRunner {
         timeout: u64,
     ) -> Result<()> {
         info!("Submitting bundle from file: {}", file.display());
-        
+
         let mut bundle_request = self.load_bundle_request(&file)?;
-        
+
         // Override settings from command line
         if atomic {
             bundle_request.atomic = true;
         }
-        
+
         if let Some(limit) = cu_limit {
             bundle_request.compute.limit = bundler_types::ComputeLimit::Fixed(limit);
         }
-        
+
         if let Some(price_str) = cu_price {
             bundle_request.compute.price = if price_str == "auto" {
                 bundler_types::ComputePrice::Auto
             } else {
-                let price: u64 = price_str.parse()
-                    .context("Invalid compute unit price")?;
+                let price: u64 = price_str.parse().context("Invalid compute unit price")?;
                 bundler_types::ComputePrice::Fixed(price)
             };
         }
-        
+
         // Submit the bundle
         match self.service.process_bundle(bundle_request).await {
             Ok(response) => {
@@ -246,35 +244,63 @@ impl CliRunner {
                 println!("Request ID: {}", response.request_id);
                 println!("Status: {:?}", response.status);
                 println!("Transactions: {}", response.transactions.len());
-                
+
                 // Show transaction signatures
                 for (i, tx_result) in response.transactions.iter().enumerate() {
-                    println!("  Transaction {}: {}", i + 1, tx_result.signature);
-                    if let Some(slot) = tx_result.slot {
-                        println!("    Slot: {}", slot);
-                    }
+                    let signature_display = tx_result
+                        .signature
+                        .as_ref()
+                        .map(|sig| sig.to_string())
+                        .unwrap_or_else(|| "N/A".to_string());
+
+                    println!("  Transaction {}: {}", i + 1, signature_display);
                     println!("    Status: {:?}", tx_result.status);
-                    
+
                     if let Some(error) = &tx_result.error {
-                        println!("    Error: {}", error.message);
+                        println!("    Error: {}", error);
+                    }
+
+                    if let Some(cu) = tx_result.compute_units_consumed {
+                        println!("    Compute units: {}", cu);
+                    }
+
+                    if let Some(fee) = tx_result.fee_paid_lamports {
+                        println!("    Fee paid: {} lamports", fee);
+                    }
+
+                    if !tx_result.logs.is_empty() {
+                        println!("    Logs:");
+                        for log in &tx_result.logs {
+                            println!("      {}", log);
+                        }
                     }
                 }
-                
+
                 // Show metrics
                 println!("\nMetrics:");
                 println!("  Total latency: {}ms", response.metrics.total_latency_ms);
-                println!("  Simulation time: {}ms", response.metrics.simulation_time_ms);
+                println!(
+                    "  Simulation time: {}ms",
+                    response.metrics.simulation_time_ms
+                );
                 println!("  Signing time: {}ms", response.metrics.signing_time_ms);
-                println!("  Submission time: {}ms", response.metrics.submission_time_ms);
-                println!("  Confirmation time: {}ms", response.metrics.confirmation_time_ms);
+                println!(
+                    "  Submission time: {}ms",
+                    response.metrics.submission_time_ms
+                );
+                println!(
+                    "  Confirmation time: {}ms",
+                    response.metrics.confirmation_time_ms
+                );
                 println!("  Retry attempts: {}", response.metrics.retry_attempts);
-                
+
                 // Wait for finalization if requested
                 if wait && response.status != BundleStatus::Failed {
                     println!("\nWaiting for finalization...");
-                    self.wait_for_finalization(&response.transactions, timeout).await?;
+                    self.wait_for_finalization(&response.transactions, timeout)
+                        .await?;
                 }
-                
+
                 // Exit with error code if bundle failed
                 if response.status == BundleStatus::Failed {
                     std::process::exit(1);
@@ -285,50 +311,53 @@ impl CliRunner {
                 std::process::exit(1);
             }
         }
-        
+
         Ok(())
     }
-    
+
     /// Handle status command
     async fn status_command(&self, id: String, verbose: bool) -> Result<()> {
         info!("Checking status for: {}", id);
-        
+
         // Try to parse as signature first
         if let Ok(signature) = id.parse::<solana_sdk::signature::Signature>() {
             match self.service.get_transaction(&signature).await {
                 Ok(Some(tx)) => {
                     println!("Transaction found: {}", signature);
-                    
+
                     if let Some(meta) = &tx.transaction.meta {
-                        println!("Status: {:?}", if meta.err.is_none() { 
-                            TransactionStatus::Finalized 
-                        } else { 
-                            TransactionStatus::Failed 
-                        });
-                        
+                        println!(
+                            "Status: {:?}",
+                            if meta.err.is_none() {
+                                TransactionStatus::Finalized
+                            } else {
+                                TransactionStatus::Failed
+                            }
+                        );
+
                         println!("Slot: {}", tx.slot);
-                        
+
                         println!("Fee: {} lamports", meta.fee);
-                        
+
                         match meta.compute_units_consumed {
-                            solana_transaction_status_client_types::option_serializer::OptionSerializer::Some(cu) => {
+                            OptionSerializer::Some(cu) => {
                                 println!("Compute units: {}", cu);
-                            },
+                            }
                             _ => {}
                         }
-                        
+
                         if verbose {
                             match &meta.log_messages {
-                                solana_transaction_status_client_types::option_serializer::OptionSerializer::Some(logs) => {
+                                OptionSerializer::Some(logs) => {
                                     println!("\nLogs:");
                                     for log in logs {
                                         println!("  {}", log);
                                     }
-                                },
+                                }
                                 _ => {}
                             }
                         }
-                        
+
                         if let Some(err) = &meta.err {
                             println!("Error: {:?}", err);
                         }
@@ -347,14 +376,14 @@ impl CliRunner {
             println!("Request ID status checking not implemented yet");
             println!("Use transaction signature instead");
         }
-        
+
         Ok(())
     }
-    
+
     /// Handle health command
     async fn health_command(&self, verbose: bool) -> Result<()> {
         info!("Checking bundler health");
-        
+
         match self.service.health_check().await {
             Ok(health) => {
                 let all_healthy = health.values().all(|status| status == "healthy");
@@ -363,9 +392,9 @@ impl CliRunner {
                 } else {
                     println!("❌ Bundler is unhealthy");
                 }
-                
-                println!("Last check: {}", chrono::Utc::now().to_rfc3339());
-                
+
+                println!("Last check: {}", Utc::now().to_rfc3339());
+
                 if verbose {
                     println!("\nComponent status:");
                     for (name, status) in &health {
@@ -373,7 +402,7 @@ impl CliRunner {
                         println!("  {} {} ({})", status_icon, name, status);
                     }
                 }
-                
+
                 if !all_healthy {
                     std::process::exit(1);
                 }
@@ -383,17 +412,17 @@ impl CliRunner {
                 std::process::exit(1);
             }
         }
-        
+
         Ok(())
     }
-    
+
     /// Handle config command
     async fn config_command(&self, show: bool, validate: bool) -> Result<()> {
         if show {
             println!("Current configuration:");
             println!("{}", toml::to_string_pretty(&self.config)?);
         }
-        
+
         if validate {
             match self.config.validate() {
                 Ok(_) => println!("✅ Configuration is valid"),
@@ -403,58 +432,66 @@ impl CliRunner {
                 }
             }
         }
-        
+
         if !show && !validate {
             println!("Use --show to display configuration or --validate to check it");
         }
-        
+
         Ok(())
     }
-    
+
     /// Load bundle request from JSON file
     fn load_bundle_request(&self, file: &PathBuf) -> Result<BundleRequest> {
         let content = std::fs::read_to_string(file)
             .with_context(|| format!("Failed to read file: {}", file.display()))?;
-        
+
         let request: BundleRequest = serde_json::from_str(&content)
             .with_context(|| format!("Failed to parse JSON from: {}", file.display()))?;
-        
+
         Ok(request)
     }
-    
+
     /// Wait for transactions to be finalized
     async fn wait_for_finalization(
         &self,
         transactions: &[bundler_types::TransactionResult],
         timeout_seconds: u64,
     ) -> Result<()> {
-        use tokio::time::{timeout, Duration, sleep};
-        
+        use tokio::time::{sleep, timeout, Duration};
+
         let timeout_duration = Duration::from_secs(timeout_seconds);
         let start_time = std::time::Instant::now();
-        
+
         for tx_result in transactions {
             if tx_result.status == TransactionStatus::Failed {
                 continue; // Skip failed transactions
             }
-            
+
+            let Some(signature) = &tx_result.signature else {
+                warn!("Skipping finalization check for transaction without signature");
+                continue;
+            };
+
+            let signature_value = *signature;
+
             let remaining_time = timeout_duration.saturating_sub(start_time.elapsed());
             if remaining_time.is_zero() {
                 warn!("Timeout waiting for finalization");
                 break;
             }
-            
-            println!("Waiting for transaction {} to finalize...", tx_result.signature);
-            
-            let result = timeout(remaining_time, async {
+
+            println!("Waiting for transaction {} to finalize...", signature_value);
+
+            let finalize_future = async move {
                 loop {
-                    match self.service.confirm_transaction(
-                        &tx_result.signature,
-                        solana_sdk::commitment_config::CommitmentLevel::Finalized,
-                    ).await {
+                    match self
+                        .service
+                        .confirm_transaction(&signature_value, CommitmentLevel::Finalized)
+                        .await
+                    {
                         Ok(true) => {
-                            println!("✅ Transaction {} finalized", tx_result.signature);
-                            return Ok(());
+                            println!("✅ Transaction {} finalized", signature_value);
+                            break;
                         }
                         Ok(false) => {
                             sleep(Duration::from_millis(500)).await;
@@ -465,16 +502,18 @@ impl CliRunner {
                         }
                     }
                 }
-            }).await;
-            
-            match result {
-                Ok(_) => {} // Transaction finalized
-                Err(_) => {
-                    warn!("Timeout waiting for transaction {} to finalize", tx_result.signature);
-                }
+            };
+
+            let result = timeout(remaining_time, finalize_future).await;
+
+            if result.is_err() {
+                warn!(
+                    "Timeout waiting for transaction {} to finalize",
+                    signature_value
+                );
             }
         }
-        
+
         Ok(())
     }
 }
@@ -489,10 +528,11 @@ pub fn init_logging(level: &str, format: &str) -> Result<()> {
         "error" => tracing::Level::ERROR,
         _ => return Err(anyhow::anyhow!("Invalid log level: {}", level)),
     };
-    
-    let subscriber = tracing_subscriber::registry()
-        .with(tracing_subscriber::filter::LevelFilter::from_level(level_filter));
-    
+
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::filter::LevelFilter::from_level(level_filter),
+    );
+
     match format.to_lowercase().as_str() {
         "json" => {
             subscriber
@@ -506,31 +546,31 @@ pub fn init_logging(level: &str, format: &str) -> Result<()> {
         }
         _ => return Err(anyhow::anyhow!("Invalid log format: {}", format)),
     }
-    
+
     Ok(())
 }
 
 /// Main CLI entry point
 pub async fn run_cli() -> Result<()> {
     let cli = Cli::parse();
-    
+
     // Initialize logging
     init_logging(&cli.log_level, &cli.log_format)?;
-    
+
     // Create and run CLI
     let runner = CliRunner::new(&cli.config).await?;
     runner.run(cli.command).await?;
-    
+
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::NamedTempFile;
-    use std::io::Write;
     use bundler_types::{ComputeConfig, ComputeLimit, ComputePrice, InstructionData};
-    use solana_sdk::{pubkey::Pubkey, instruction::AccountMeta};
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey};
+    use std::io::Write;
+    use tempfile::NamedTempFile;
     use uuid::Uuid;
 
     #[test]
@@ -538,7 +578,7 @@ mod tests {
         // Test basic CLI parsing
         let args = vec!["bundler", "submit", "--config", "test.toml", "bundle.json"];
         let cli = Cli::try_parse_from(args).unwrap();
-        
+
         assert_eq!(cli.config, "test.toml");
         match cli.command {
             Commands::Submit { bundle_file } => {
@@ -552,10 +592,10 @@ mod tests {
     fn test_cli_with_verbose_flag() {
         let args = vec!["bundler", "--verbose", "status"];
         let cli = Cli::try_parse_from(args).unwrap();
-        
+
         assert_eq!(cli.log_level, "debug");
         match cli.command {
-            Commands::Status => {},
+            Commands::Status => {}
             _ => panic!("Expected Status command"),
         }
     }
@@ -564,10 +604,10 @@ mod tests {
     fn test_cli_with_custom_log_format() {
         let args = vec!["bundler", "--log-format", "json", "health"];
         let cli = Cli::try_parse_from(args).unwrap();
-        
+
         assert_eq!(cli.log_format, "json");
         match cli.command {
-            Commands::Health => {},
+            Commands::Health => {}
             _ => panic!("Expected Health command"),
         }
     }
@@ -584,19 +624,15 @@ mod tests {
                 max_price_lamports: 50000,
             },
             alt_tables: vec![],
-            instructions: vec![
-                InstructionData {
-                    program_id: Pubkey::new_unique(),
-                    keys: vec![
-                        AccountMeta {
-                            pubkey: Pubkey::new_unique(),
-                            is_signer: true,
-                            is_writable: true,
-                        }
-                    ],
-                    data_b64: base64::engine::general_purpose::STANDARD.encode(&[1, 2, 3, 4]),
-                }
-            ],
+            instructions: vec![InstructionData {
+                program_id: Pubkey::new_unique(),
+                keys: vec![AccountMeta {
+                    pubkey: Pubkey::new_unique(),
+                    is_signer: true,
+                    is_writable: true,
+                }],
+                data_b64: base64::engine::general_purpose::STANDARD.encode(&[1, 2, 3, 4]),
+            }],
             signers: vec![],
             metadata: std::collections::HashMap::new(),
         };
@@ -609,7 +645,10 @@ mod tests {
         let loaded_request = load_bundle_request(temp_file.path()).unwrap();
         assert_eq!(bundle_request.request_id, loaded_request.request_id);
         assert_eq!(bundle_request.atomic, loaded_request.atomic);
-        assert_eq!(bundle_request.instructions.len(), loaded_request.instructions.len());
+        assert_eq!(
+            bundle_request.instructions.len(),
+            loaded_request.instructions.len()
+        );
     }
 
     #[test]
@@ -798,13 +837,11 @@ worker_threads = 4
                 max_price_lamports: 50000,
             },
             alt_tables: vec![],
-            instructions: vec![
-                InstructionData {
-                    program_id: Pubkey::new_unique(),
-                    keys: vec![],
-                    data_b64: base64::engine::general_purpose::STANDARD.encode(&[]),
-                }
-            ],
+            instructions: vec![InstructionData {
+                program_id: Pubkey::new_unique(),
+                keys: vec![],
+                data_b64: base64::engine::general_purpose::STANDARD.encode(&[]),
+            }],
             signers: vec![],
             metadata: std::collections::HashMap::new(),
         };
@@ -832,7 +869,7 @@ worker_threads = 4
     fn test_default_values() {
         let args = vec!["bundler", "status"];
         let cli = Cli::try_parse_from(args).unwrap();
-        
+
         assert_eq!(cli.config, "bundler.config.toml");
         assert_eq!(cli.log_level, "info");
         assert_eq!(cli.log_format, "pretty");

--- a/crates/bundler-service/Cargo.toml
+++ b/crates/bundler-service/Cargo.toml
@@ -29,6 +29,8 @@ solana-sdk.workspace = true
 chrono.workspace = true
 tower.workspace = true
 tower-http.workspace = true
+solana-transaction-status.workspace = true
+solana-commitment-config.workspace = true
 
 [dev-dependencies]
 axum-test = "15.0"

--- a/crates/bundler-service/src/lib.rs
+++ b/crates/bundler-service/src/lib.rs
@@ -6,15 +6,15 @@ use axum::{
     Router,
 };
 use base64::Engine;
+use bundler_config::BundlerConfig;
 use bundler_core::BundlerService;
-use bundler_types::{BundleRequest, BundleResponse, BundlerError, BundlerResult};
-use chrono::{DateTime, Utc};
+use bundler_types::{BundleRequest, BundleResponse};
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use solana_transaction_status::option_serializer::OptionSerializer;
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 use tokio::net::TcpListener;
-use tower::ServiceBuilder;
-use tower_http::cors::CorsLayer;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 /// HTTP service for the Solana transaction bundler
 pub struct HttpService {
@@ -72,52 +72,55 @@ pub struct ComponentHealth {
 }
 
 /// Error response
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ErrorResponse {
     pub error: String,
     pub details: Option<String>,
+    pub timestamp: Option<String>,
 }
 
 impl HttpService {
     /// Create a new HTTP service
-    pub async fn new(config: BundlerConfig) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn new(
+        config: BundlerConfig,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let bundler_service = Arc::new(BundlerService::new(config.clone()).await?);
-        
+
         Ok(Self {
             bundler_service,
             config,
         })
     }
-    
+
     /// Create the router with all endpoints
     pub fn create_router(&self) -> Router {
         let app_state = Arc::clone(&self.bundler_service);
-        
+
         Router::new()
             // Bundle endpoints
             .route("/v1/bundle", post(submit_bundle))
             .route("/v1/bundle/simulate", post(simulate_bundle))
-            
             // Status endpoints
             .route("/v1/status/:signature", get(get_transaction_status))
             .route("/v1/health", get(health_check))
-            
             // Info endpoints
             .route("/v1/info", get(get_service_info))
             .route("/", get(root_handler))
-            
             .with_state(app_state)
     }
-    
+
     /// Start the HTTP server
-    pub async fn serve(&self, addr: SocketAddr) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    pub async fn serve(
+        &self,
+        addr: SocketAddr,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let app = self.create_router();
-        
+
         info!("Starting HTTP server on {}", addr);
-        
+
         let listener = TcpListener::bind(addr).await?;
         axum::serve(listener, app).await?;
-        
+
         Ok(())
     }
 }
@@ -127,8 +130,11 @@ async fn submit_bundle(
     State(service): State<Arc<BundlerService>>,
     Json(request): Json<SubmitBundleRequest>,
 ) -> Result<Json<SubmitBundleResponse>, (StatusCode, Json<ErrorResponse>)> {
-    info!("Received bundle submission request: {}", request.bundle.request_id);
-    
+    info!(
+        "Received bundle submission request: {}",
+        request.bundle.request_id
+    );
+
     match service.process_bundle(request.bundle).await {
         Ok(response) => {
             info!("Bundle processed successfully: {}", response.request_id);
@@ -141,6 +147,7 @@ async fn submit_bundle(
                 Json(ErrorResponse {
                     error: "Bundle processing failed".to_string(),
                     details: Some(format!("{}", e)),
+                    timestamp: Some(Utc::now().to_rfc3339()),
                 }),
             ))
         }
@@ -152,17 +159,23 @@ async fn simulate_bundle(
     State(service): State<Arc<BundlerService>>,
     Json(request): Json<SubmitBundleRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    info!("Received bundle simulation request: {}", request.bundle.request_id);
-    
+    info!(
+        "Received bundle simulation request: {}",
+        request.bundle.request_id
+    );
+
     // Convert instructions to Solana instructions
-    let instructions: Result<Vec<solana_sdk::instruction::Instruction>, String> = request.bundle.instructions
+    let instructions: Result<Vec<solana_sdk::instruction::Instruction>, String> = request
+        .bundle
+        .instructions
         .iter()
         .map(|ix| {
             let instruction_bytes = base64::engine::general_purpose::STANDARD
                 .decode(&ix.data_b64)
                 .map_err(|e| format!("Invalid base64 data: {}", e))?;
-            
-            let accounts = ix.keys
+
+            let accounts = ix
+                .keys
                 .iter()
                 .map(|meta| solana_sdk::instruction::AccountMeta {
                     pubkey: meta.pubkey,
@@ -170,7 +183,7 @@ async fn simulate_bundle(
                     is_writable: meta.is_writable,
                 })
                 .collect::<Vec<_>>();
-            
+
             Ok(solana_sdk::instruction::Instruction {
                 program_id: ix.program_id,
                 accounts,
@@ -178,7 +191,7 @@ async fn simulate_bundle(
             })
         })
         .collect();
-    
+
     let instructions = match instructions {
         Ok(ix) => ix,
         Err(e) => {
@@ -187,14 +200,15 @@ async fn simulate_bundle(
                 Json(ErrorResponse {
                     error: "Invalid instruction data".to_string(),
                     details: Some(e),
+                    timestamp: Some(Utc::now().to_rfc3339()),
                 }),
             ));
         }
     };
-    
+
     // Simulate each instruction
     let mut simulation_results = Vec::new();
-    
+
     for (i, instruction) in instructions.iter().enumerate() {
         // Create a simple transaction for simulation
         let fee_payer = match service.get_fee_payer_pubkey().await {
@@ -205,28 +219,36 @@ async fn simulate_bundle(
                     Json(ErrorResponse {
                         error: "Failed to get fee payer".to_string(),
                         details: Some(format!("{}", e)),
+                        timestamp: Some(Utc::now().to_rfc3339()),
                     }),
                 ));
             }
         };
-        
+
         let mut transaction = solana_sdk::transaction::Transaction::new_with_payer(
             &[instruction.clone()],
             Some(&fee_payer),
         );
-        
+
         // Set a dummy blockhash for simulation
         transaction.message.recent_blockhash = solana_sdk::hash::Hash::new_unique();
-        
+
         match service.simulate_transaction(&transaction).await {
             Ok(result) => {
+                let error_value = result.error.as_ref().map(|err| {
+                    serde_json::json!({
+                        "message": err.message,
+                        "retryable": err.retryable,
+                    })
+                });
+
                 simulation_results.push(serde_json::json!({
                     "instruction_index": i,
                     "success": result.success,
                     "compute_units_consumed": result.compute_units_consumed,
                     "estimated_fee": result.estimated_fee,
                     "logs": result.logs,
-                    "error": result.error,
+                    "error": error_value,
                 }));
             }
             Err(e) => {
@@ -238,7 +260,7 @@ async fn simulate_bundle(
             }
         }
     }
-    
+
     Ok(Json(serde_json::json!({
         "request_id": request.bundle.request_id,
         "simulations": simulation_results,
@@ -259,11 +281,12 @@ async fn get_transaction_status(
                 Json(ErrorResponse {
                     error: "Invalid signature format".to_string(),
                     details: None,
+                    timestamp: Some(Utc::now().to_rfc3339()),
                 }),
             ));
         }
     };
-    
+
     match service.get_transaction(&signature).await {
         Ok(Some(tx)) => {
             let status = if let Some(meta) = &tx.transaction.meta {
@@ -275,28 +298,36 @@ async fn get_transaction_status(
             } else {
                 "unknown".to_string()
             };
-            
+
             let fee = tx.transaction.meta.as_ref().map(|meta| meta.fee);
-            let compute_units = tx.transaction.meta.as_ref()
-                .and_then(|meta| match meta.compute_units_consumed {
-                    solana_transaction_status_client_types::option_serializer::OptionSerializer::Some(cu) => Some(cu as u64),
-                    _ => None,
-                });
-            
+            let compute_units =
+                tx.transaction
+                    .meta
+                    .as_ref()
+                    .and_then(|meta| match meta.compute_units_consumed {
+                        OptionSerializer::Some(cu) => Some(cu as u64),
+                        _ => None,
+                    });
+
             let logs = if params.verbose.unwrap_or(false) {
-                tx.transaction.meta.as_ref()
+                tx.transaction
+                    .meta
+                    .as_ref()
                     .and_then(|meta| match &meta.log_messages {
-                        solana_transaction_status_client_types::option_serializer::OptionSerializer::Some(logs) => Some(logs.clone()),
+                        OptionSerializer::Some(logs) => Some(logs.clone()),
                         _ => None,
                     })
             } else {
                 None
             };
-            
-            let error = tx.transaction.meta.as_ref()
+
+            let error = tx
+                .transaction
+                .meta
+                .as_ref()
                 .and_then(|meta| meta.err.as_ref())
                 .map(|err| format!("{:?}", err));
-            
+
             Ok(Json(TransactionStatusResponse {
                 signature: signature_str,
                 status,
@@ -307,15 +338,14 @@ async fn get_transaction_status(
                 error,
             }))
         }
-        Ok(None) => {
-            Err((
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse {
-                    error: "Transaction not found".to_string(),
-                    details: None,
-                }),
-            ))
-        }
+        Ok(None) => Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: "Transaction not found".to_string(),
+                details: None,
+                timestamp: Some(Utc::now().to_rfc3339()),
+            }),
+        )),
         Err(e) => {
             error!("Failed to get transaction: {}", e);
             Err((
@@ -323,6 +353,7 @@ async fn get_transaction_status(
                 Json(ErrorResponse {
                     error: "Failed to get transaction".to_string(),
                     details: Some(format!("{}", e)),
+                    timestamp: Some(Utc::now().to_rfc3339()),
                 }),
             ))
         }
@@ -338,27 +369,25 @@ async fn health_check(
             let components = health
                 .iter()
                 .map(|(name, status)| {
-                    (name.clone(), ComponentHealth {
-                        healthy: status == "healthy",
-                        message: Some(status.clone()),
-                        last_success: Some(Utc::now().to_rfc3339()),
-                    })
+                    (
+                        name.clone(),
+                        ComponentHealth {
+                            healthy: status == "healthy",
+                            message: Some(status.clone()),
+                            last_success: Some(Utc::now().to_rfc3339()),
+                        },
+                    )
                 })
-                .collect::<Vec<_>>();
-            
+                .collect::<HashMap<_, _>>();
+
             let all_healthy = health.values().all(|status| status == "healthy");
-            let status_code = if all_healthy {
-                StatusCode::OK
-            } else {
-                StatusCode::SERVICE_UNAVAILABLE
-            };
-            
+
             let response = HealthResponse {
                 healthy: all_healthy,
                 timestamp: Utc::now().to_rfc3339(),
                 components,
             };
-            
+
             Ok(Json(response))
         }
         Err(e) => {
@@ -368,6 +397,7 @@ async fn health_check(
                 Json(ErrorResponse {
                     error: "Health check failed".to_string(),
                     details: Some(format!("{}", e)),
+                    timestamp: Some(Utc::now().to_rfc3339()),
                 }),
             ))
         }
@@ -375,9 +405,7 @@ async fn health_check(
 }
 
 /// Get service information
-async fn get_service_info(
-    State(_service): State<Arc<BundlerService>>,
-) -> Json<serde_json::Value> {
+async fn get_service_info(State(_service): State<Arc<BundlerService>>) -> Json<serde_json::Value> {
     Json(serde_json::json!({
         "name": "Solana Transaction Bundler",
         "version": env!("CARGO_PKG_VERSION"),
@@ -406,18 +434,20 @@ async fn root_handler() -> Json<serde_json::Value> {
 }
 
 /// Start the HTTP service
-pub async fn start_service(config: BundlerConfig) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+pub async fn start_service(
+    config: BundlerConfig,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let service = HttpService::new(config.clone()).await?;
-    
+
     let addr = SocketAddr::from(([0, 0, 0, 0], config.service.port));
-    
+
     info!("Starting Solana Transaction Bundler HTTP service");
     info!("Listening on: http://{}", addr);
     info!("Health check: http://{}/v1/health", addr);
     info!("API info: http://{}/v1/info", addr);
-    
+
     service.serve(addr).await?;
-    
+
     Ok(())
 }
 
@@ -426,9 +456,11 @@ mod tests {
     use super::*;
     use axum_test::TestServer;
     use bundler_config::BundlerConfigBuilder;
-    use bundler_types::{BundleRequest, ComputeConfig, ComputeLimit, ComputePrice, InstructionData};
-    use solana_sdk::{pubkey::Pubkey, instruction::AccountMeta, signature::Signature};
+    use bundler_types::{
+        BundleRequest, ComputeConfig, ComputeLimit, ComputePrice, InstructionData,
+    };
     use serde_json::json;
+    use solana_sdk::{instruction::AccountMeta, pubkey::Pubkey, signature::Signature};
     use uuid::Uuid;
 
     async fn create_test_service() -> HttpService {
@@ -436,7 +468,7 @@ mod tests {
             .with_rpc_endpoint("https://api.devnet.solana.com".to_string(), 100)
             .build()
             .unwrap();
-        
+
         HttpService::new(config).await.unwrap()
     }
 
@@ -450,19 +482,15 @@ mod tests {
                 max_price_lamports: 50000,
             },
             alt_tables: vec![],
-            instructions: vec![
-                InstructionData {
-                    program_id: Pubkey::new_unique(),
-                    keys: vec![
-                        AccountMeta {
-                            pubkey: Pubkey::new_unique(),
-                            is_signer: true,
-                            is_writable: true,
-                        }
-                    ],
-                    data_b64: base64::engine::general_purpose::STANDARD.encode(&[1, 2, 3, 4]),
-                }
-            ],
+            instructions: vec![InstructionData {
+                program_id: Pubkey::new_unique(),
+                keys: vec![AccountMeta {
+                    pubkey: Pubkey::new_unique(),
+                    is_signer: true,
+                    is_writable: true,
+                }],
+                data_b64: base64::engine::general_purpose::STANDARD.encode(&[1, 2, 3, 4]),
+            }],
             signers: vec![],
             metadata: std::collections::HashMap::new(),
         }
@@ -473,12 +501,12 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
+
         let response = server.get("/v1/health").await;
-        
+
         // Should return some response (might be unhealthy in test environment)
         assert!(response.status_code().is_success() || response.status_code().is_server_error());
-        
+
         // Check response structure
         let body: serde_json::Value = response.json();
         assert!(body.get("healthy").is_some());
@@ -490,11 +518,11 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
+
         let response = server.get("/v1/info").await;
-        
+
         assert!(response.status_code().is_success());
-        
+
         let body: serde_json::Value = response.json();
         assert!(body.get("name").is_some());
         assert!(body.get("version").is_some());
@@ -506,11 +534,11 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
+
         let response = server.get("/").await;
-        
+
         assert!(response.status_code().is_success());
-        
+
         let body: serde_json::Value = response.json();
         assert!(body.get("message").is_some());
         assert!(body.get("endpoints").is_some());
@@ -521,17 +549,14 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
+
         let bundle_request = create_test_bundle_request();
-        
-        let response = server
-            .post("/v1/bundle")
-            .json(&bundle_request)
-            .await;
-        
+
+        let response = server.post("/v1/bundle").json(&bundle_request).await;
+
         // May fail due to network issues, but should handle the request structure
         println!("Bundle submit response status: {}", response.status_code());
-        
+
         // Check that it's not a 404 (endpoint exists)
         assert_ne!(response.status_code(), StatusCode::NOT_FOUND);
     }
@@ -541,14 +566,14 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
+
         let response = server
             .post("/v1/bundle")
             .json(&json!({"invalid": "request"}))
             .await;
-        
+
         assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        
+
         let body: ErrorResponse = response.json();
         assert!(body.error.contains("Invalid") || body.error.contains("missing"));
     }
@@ -558,12 +583,9 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
-        let response = server
-            .post("/v1/bundle")
-            .text("")
-            .await;
-        
+
+        let response = server.post("/v1/bundle").text("").await;
+
         assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
     }
 
@@ -572,13 +594,13 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
+
         let signature = Signature::new_unique();
         let response = server.get(&format!("/v1/status/{}", signature)).await;
-        
+
         // Should not be a 400 (bad request) for valid signature format
         assert_ne!(response.status_code(), StatusCode::BAD_REQUEST);
-        
+
         // May be 404 (not found) or other status depending on implementation
         println!("Status endpoint response: {}", response.status_code());
     }
@@ -588,11 +610,11 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
+
         let response = server.get("/v1/status/invalid-signature").await;
-        
+
         assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        
+
         let body: ErrorResponse = response.json();
         assert!(body.error.contains("Invalid signature format"));
     }
@@ -602,9 +624,9 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
+
         let response = server.get("/v1/info").await;
-        
+
         // Check for CORS headers
         let headers = response.headers();
         // CORS headers might be present depending on configuration
@@ -616,11 +638,11 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
+
         let response = server.get("/v1/info").await;
-        
+
         assert!(response.status_code().is_success());
-        
+
         // Should return JSON content type
         let content_type = response.headers().get("content-type");
         if let Some(ct) = content_type {
@@ -633,33 +655,28 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
+
         // Create a large bundle request
         let mut large_request = create_test_bundle_request();
-        
+
         // Add many instructions to make it large
         for _ in 0..100 {
             large_request.instructions.push(InstructionData {
                 program_id: Pubkey::new_unique(),
-                keys: vec![
-                    AccountMeta {
-                        pubkey: Pubkey::new_unique(),
-                        is_signer: false,
-                        is_writable: false,
-                    }
-                ],
+                keys: vec![AccountMeta {
+                    pubkey: Pubkey::new_unique(),
+                    is_signer: false,
+                    is_writable: false,
+                }],
                 data_b64: base64::engine::general_purpose::STANDARD.encode(&vec![0u8; 1000]),
             });
         }
-        
-        let response = server
-            .post("/v1/bundle")
-            .json(&large_request)
-            .await;
-        
+
+        let response = server.post("/v1/bundle").json(&large_request).await;
+
         // Should handle large requests (may fail due to size limits or network issues)
         println!("Large request response: {}", response.status_code());
-        
+
         // Should not be a 404 (endpoint exists)
         assert_ne!(response.status_code(), StatusCode::NOT_FOUND);
     }
@@ -669,14 +686,14 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
+
         // Test unsupported methods on various endpoints
         let response = server.put("/v1/info").await;
         assert_eq!(response.status_code(), StatusCode::METHOD_NOT_ALLOWED);
-        
+
         let response = server.delete("/v1/health").await;
         assert_eq!(response.status_code(), StatusCode::METHOD_NOT_ALLOWED);
-        
+
         let response = server.patch("/v1/bundle").await;
         assert_eq!(response.status_code(), StatusCode::METHOD_NOT_ALLOWED);
     }
@@ -686,13 +703,13 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
+
         let response = server.get("/v1/nonexistent").await;
         assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
-        
+
         let response = server.get("/v2/info").await;
         assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
-        
+
         let response = server.get("/invalid").await;
         assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
     }
@@ -702,12 +719,12 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
+
         // Test that the service can handle requests without timing out immediately
         let start = std::time::Instant::now();
         let response = server.get("/v1/info").await;
         let duration = start.elapsed();
-        
+
         assert!(response.status_code().is_success());
         assert!(duration.as_secs() < 30); // Should respond quickly for info endpoint
     }
@@ -717,18 +734,16 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
+
         // Test multiple concurrent requests
         let mut handles = vec![];
-        
+
         for _ in 0..10 {
             let server_clone = server.clone();
-            let handle = tokio::spawn(async move {
-                server_clone.get("/v1/info").await
-            });
+            let handle = tokio::spawn(async move { server_clone.get("/v1/info").await });
             handles.push(handle);
         }
-        
+
         // Wait for all requests to complete
         for handle in handles {
             let response = handle.await.unwrap();
@@ -741,11 +756,11 @@ mod tests {
         let service = create_test_service().await;
         let app = service.create_router();
         let server = TestServer::new(app).unwrap();
-        
+
         let response = server.get("/v1/status/invalid").await;
-        
+
         assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
-        
+
         // Check error response format
         let body: ErrorResponse = response.json();
         assert!(!body.error.is_empty());


### PR DESCRIPTION
## Summary
- add chrono, solana-transaction-status, and solana-commitment-config dependencies to the CLI and service crates
- update the CLI to import the new OptionSerializer and CommitmentLevel types, format optional signature output, and improve finalization polling
- refresh the service to use the new OptionSerializer module, include timestamps in error payloads, and serialize simulation errors safely

## Testing
- `cargo fmt`
- `cargo build --workspace`
- `cargo test --workspace` *(fails: existing bundler-core and CLI tests reference removed Solana APIs and outdated command variants)*

------
https://chatgpt.com/codex/tasks/task_e_68da28b6d6688331bd560ccf8b925242